### PR TITLE
Add polynomial minimizer solver

### DIFF
--- a/bench/compareMinimizers.js
+++ b/bench/compareMinimizers.js
@@ -1,0 +1,42 @@
+const { positiveGlobalMinimizer } = require('../dist-cjs/simulation/utils/PolynomialMinimizer.js');
+const { positiveGlobalMinimizerJT } = require('../dist-cjs/simulation/utils/PolynomialMinimizerJT.js');
+const { positiveGlobalMinimizerDK } = require('../dist-cjs/simulation/utils/PolynomialMinimizerDK.js');
+
+function randomPolynomial(deg) {
+  const coeffs = [];
+  for (let i = 0; i <= deg; i++) {
+    coeffs.push(Math.random() * 2 - 1);
+  }
+  coeffs[deg] = Math.abs(coeffs[deg]) + 1; // ensure positive leading coeff
+  return coeffs;
+}
+
+function benchmark(iterations, degree) {
+  const poly = randomPolynomial(degree);
+  const startNaive = process.hrtime.bigint();
+  for (let i = 0; i < iterations; i++) {
+    positiveGlobalMinimizer(poly);
+  }
+  const tNaive = Number(process.hrtime.bigint() - startNaive) / 1e6;
+
+  const startJT = process.hrtime.bigint();
+  for (let i = 0; i < iterations; i++) {
+    positiveGlobalMinimizerJT(poly);
+  }
+  const tJT = Number(process.hrtime.bigint() - startJT) / 1e6;
+
+  const startDK = process.hrtime.bigint();
+  for (let i = 0; i < iterations; i++) {
+    positiveGlobalMinimizerDK(poly);
+  }
+  const tDK = Number(process.hrtime.bigint() - startDK) / 1e6;
+
+  console.log(`Degree ${degree} polynomial over ${iterations} runs`);
+  console.log(`Naive solver:        ${tNaive.toFixed(2)} ms`);
+  console.log(`Jenkins-Traub solver:${tJT.toFixed(2)} ms`);
+  console.log(`Durand-Kerner solver:${tDK.toFixed(2)} ms`);
+}
+
+const degree = parseInt(process.argv[2] || '10', 10);
+const iterations = parseInt(process.argv[3] || '100', 10);
+benchmark(iterations, degree);

--- a/bench/runBenchmark.js
+++ b/bench/runBenchmark.js
@@ -1,0 +1,40 @@
+const { positiveGlobalMinimizer } = require('../dist-cjs/simulation/utils/PolynomialMinimizer.js');
+const { positiveGlobalMinimizerJT } = require('../dist-cjs/simulation/utils/PolynomialMinimizerJT.js');
+const { positiveGlobalMinimizerDK } = require('../dist-cjs/simulation/utils/PolynomialMinimizerDK.js');
+
+function randomPolynomial(deg) {
+  const coeffs = [];
+  for (let i = 0; i <= deg; i++) {
+    coeffs.push(Math.random() * 2 - 1);
+  }
+  coeffs[deg] = Math.abs(coeffs[deg]) + 1;
+  return coeffs;
+}
+
+function measure(fn, poly, iterations) {
+  const start = process.hrtime.bigint();
+  for (let i = 0; i < iterations; i++) fn(poly);
+  return Number(process.hrtime.bigint() - start) / 1e6;
+}
+
+function benchmark(degree, iterations) {
+  const poly = randomPolynomial(degree);
+  const naive = measure(positiveGlobalMinimizer, poly, iterations);
+  const jt = measure(positiveGlobalMinimizerJT, poly, iterations);
+  const dk = measure(positiveGlobalMinimizerDK, poly, iterations);
+  return { degree, iterations, naive, jt, dk };
+}
+
+function run() {
+  const degrees = [5, 10, 20, 30, 40];
+  const iterations = 100;
+  const results = degrees.map(d => benchmark(d, iterations));
+  for (const r of results) {
+    console.log(`Degree ${r.degree} over ${r.iterations} runs`);
+    console.log(`  Naive: ${r.naive.toFixed(2)} ms`);
+    console.log(`  Jenkins-Traub: ${r.jt.toFixed(2)} ms`);
+    console.log(`  Durand-Kerner: ${r.dk.toFixed(2)} ms`);
+  }
+}
+
+run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,11 @@
       "dependencies": {
         "css-loader": "^7.1.1",
         "dat.gui": "^0.7.9",
+        "durand-kerner": "^1.0.0",
+        "poly-roots": "^1.0.8",
         "polynomial-real-root-finding": "^1.0.1",
-        "three": "^0.126.1"
+        "three": "^0.126.1",
+        "ts-node": "^10.9.2"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -627,6 +630,28 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -1149,7 +1174,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1176,8 +1200,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "devOptional": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1269,6 +1292,30 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.1",
@@ -1396,7 +1443,6 @@
       "version": "20.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
       "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
-      "devOptional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1653,7 +1699,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1668,6 +1713,18 @@
       "devOptional": true,
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -1778,6 +1835,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2209,6 +2272,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2322,6 +2391,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2329,6 +2407,15 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/durand-kerner": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/durand-kerner/-/durand-kerner-1.0.0.tgz",
+      "integrity": "sha512-v1ysLXimX2gqOuVCYn5mkEQO3ZNBxXLHEXTRntE7UNTXgU068ZrN/Gh2ez7Di6IH9Jap7kso2PwMpzeEOGqI4A==",
+      "license": "MIT",
+      "dependencies": {
+        "next-pow-2": "^1.0.0"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3892,8 +3979,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -4043,6 +4129,12 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "devOptional": true
+    },
+    "node_modules/next-pow-2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-pow-2/-/next-pow-2-1.0.0.tgz",
+      "integrity": "sha512-q+HqJpSkvVqOo75HUY5h1JurDXxHMvjPi5INOfZr3QiSlYUPBzRs6JZx8VPWf7pf18yg6NHUWvwfUILGxJ8ekg==",
+      "license": "MIT"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4265,6 +4357,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/poly-roots": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/poly-roots/-/poly-roots-1.0.8.tgz",
+      "integrity": "sha512-KNQiE4Z5CDOtEuNzZO0fuG4JivZNC90aIGzkTn7Sgp2RP+k2ZETFVDolze8Uwo6G0Ic40cY60IGrbMSO24vEWw==",
+      "license": "MIT"
     },
     "node_modules/polynomial-real-root-finding": {
       "version": "1.0.1",
@@ -5182,6 +5280,49 @@
         "node": ">= 8"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5195,7 +5336,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5207,8 +5347,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -5265,6 +5404,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -5589,6 +5734,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,15 @@
   "scripts": {
     "test": "jest",
     "build": "webpack",
-    "compile": "tsc"
+    "compile": "tsc",
+    "benchmark": "node bench/runBenchmark.js"
   },
   "jest": {
     "preset": "ts-jest",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(polynomial-real-root-finding)/)"
+    ]
   },
   "repository": {
     "type": "git",
@@ -31,8 +35,11 @@
   "dependencies": {
     "css-loader": "^7.1.1",
     "dat.gui": "^0.7.9",
+    "durand-kerner": "^1.0.0",
+    "poly-roots": "^1.0.8",
     "polynomial-real-root-finding": "^1.0.1",
-    "three": "^0.126.1"
+    "three": "^0.126.1",
+    "ts-node": "^10.9.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/src/simulation/utils/PolynomialMinimizer.ts
+++ b/src/simulation/utils/PolynomialMinimizer.ts
@@ -1,0 +1,55 @@
+import {
+    Polynomial,
+    polynomialDerivative,
+    evaluatePolynomial,
+    findPositiveRoots,
+} from './PolynomialUtils';
+
+/**
+ * Finds a positive global minimizer for the given polynomial.
+ *
+ * @param polynomial Polynomial coefficients in increasing order of degree.
+ * @param precision Precision used for root finding.
+ * @returns The smallest positive global minimizer, or null if none exists.
+ */
+export function positiveGlobalMinimizer(polynomial: Polynomial, precision = 1e-7): number | null {
+    if (polynomial.length === 0) {
+        throw new Error('Polynomial must have at least one coefficient.');
+    }
+
+    // Remove leading zeros
+    let deg = polynomial.length - 1;
+    while (deg > 0 && Math.abs(polynomial[deg]) < Number.EPSILON) {
+        deg--;
+    }
+    polynomial = polynomial.slice(0, deg + 1);
+
+    const leadingCoeff = polynomial[polynomial.length - 1];
+    // If the leading coefficient is negative the polynomial is unbounded below on positive reals
+    if (leadingCoeff < 0) {
+        return null;
+    }
+
+    const derivative = polynomialDerivative(polynomial);
+    const candidateRoots = findPositiveRoots(derivative, precision);
+
+    let minimizer: number | null = null;
+    let minValue = Infinity;
+
+    const evalAt = (x: number) => evaluatePolynomial(polynomial, x);
+
+    for (const r of candidateRoots) {
+        const val = evalAt(r);
+        if (val < minValue) {
+            minValue = val;
+            minimizer = r;
+        }
+    }
+
+    const valueAtZero = evalAt(0);
+    if (minimizer === null || valueAtZero <= minValue) {
+        return null;
+    }
+
+    return minimizer;
+}

--- a/src/simulation/utils/PolynomialMinimizerDK.ts
+++ b/src/simulation/utils/PolynomialMinimizerDK.ts
@@ -1,0 +1,60 @@
+import durandKerner from 'durand-kerner';
+import {
+    Polynomial,
+    evaluatePolynomial,
+    polynomialDerivative,
+} from './PolynomialUtils';
+
+/**
+ * Finds a positive global minimizer using Durand-Kerner for derivative roots.
+ * @param polynomial Coefficients in increasing order of degree
+ * @param precision Imaginary tolerance when filtering roots
+ */
+export function positiveGlobalMinimizerDK(polynomial: Polynomial, precision = 1e-7): number | null {
+    if (polynomial.length === 0) {
+        throw new Error('Polynomial must have at least one coefficient.');
+    }
+
+    let deg = polynomial.length - 1;
+    while (deg > 0 && Math.abs(polynomial[deg]) < Number.EPSILON) {
+        deg--;
+    }
+    polynomial = polynomial.slice(0, deg + 1);
+    const leadingCoeff = polynomial[polynomial.length - 1];
+    if (leadingCoeff < 0) {
+        return null;
+    }
+
+    const derivative = polynomialDerivative(polynomial);
+    if (derivative.length <= 1) {
+        return null;
+    }
+
+    const re = derivative.slice();
+    const im = new Array(re.length).fill(0);
+    const [rootsRe, rootsIm] = durandKerner(re, im);
+    const candidateRoots: number[] = [];
+    for (let i = 0; i < rootsRe.length; i++) {
+        if (Math.abs(rootsIm[i]) <= precision && rootsRe[i] > 0) {
+            candidateRoots.push(rootsRe[i]);
+        }
+    }
+    candidateRoots.sort((a, b) => a - b);
+
+    let minimizer: number | null = null;
+    let minValue = Infinity;
+    const evalAt = (x: number) => evaluatePolynomial(polynomial, x);
+    for (const r of candidateRoots) {
+        const val = evalAt(r);
+        if (val < minValue) {
+            minValue = val;
+            minimizer = r;
+        }
+    }
+
+    const valueAtZero = evalAt(0);
+    if (minimizer === null || valueAtZero <= minValue) {
+        return null;
+    }
+    return minimizer;
+}

--- a/src/simulation/utils/PolynomialMinimizerJT.ts
+++ b/src/simulation/utils/PolynomialMinimizerJT.ts
@@ -1,0 +1,60 @@
+import roots from 'poly-roots';
+import {
+    Polynomial,
+    evaluatePolynomial,
+    polynomialDerivative,
+} from './PolynomialUtils';
+
+/**
+ * Finds a positive global minimizer using Jenkins–Traub for derivative roots.
+ * @param polynomial Coefficients in increasing order of degree
+ * @param precision Imaginary tolerance when filtering roots
+ */
+export function positiveGlobalMinimizerJT(polynomial: Polynomial, precision = 1e-7): number | null {
+    if (polynomial.length === 0) {
+        throw new Error('Polynomial must have at least one coefficient.');
+    }
+
+    let deg = polynomial.length - 1;
+    while (deg > 0 && Math.abs(polynomial[deg]) < Number.EPSILON) {
+        deg--;
+    }
+    polynomial = polynomial.slice(0, deg + 1);
+    const leadingCoeff = polynomial[polynomial.length - 1];
+    if (leadingCoeff < 0) {
+        return null;
+    }
+
+    const derivative = polynomialDerivative(polynomial);
+    if (derivative.length <= 1) {
+        // Linear or constant polynomials have no positive interior minimizer
+        return null;
+    }
+
+    const coeffDesc = derivative.slice().reverse();
+    const [re, im] = roots(coeffDesc);
+    const candidateRoots: number[] = [];
+    for (let i = 0; i < re.length; i++) {
+        if (Math.abs(im[i]) <= precision && re[i] > 0) {
+            candidateRoots.push(re[i]);
+        }
+    }
+    candidateRoots.sort((a, b) => a - b);
+
+    let minimizer: number | null = null;
+    let minValue = Infinity;
+    const evalAt = (x: number) => evaluatePolynomial(polynomial, x);
+    for (const r of candidateRoots) {
+        const val = evalAt(r);
+        if (val < minValue) {
+            minValue = val;
+            minimizer = r;
+        }
+    }
+
+    const valueAtZero = evalAt(0);
+    if (minimizer === null || valueAtZero <= minValue) {
+        return null;
+    }
+    return minimizer;
+}

--- a/src/simulation/utils/PolynomialUtils.ts
+++ b/src/simulation/utils/PolynomialUtils.ts
@@ -1,0 +1,70 @@
+export type Polynomial = number[];
+
+export function evaluatePolynomial(poly: Polynomial, x: number): number {
+    let result = poly[poly.length - 1];
+    for (let i = poly.length - 2; i >= 0; i--) {
+        result = result * x + poly[i];
+    }
+    return result;
+}
+
+export function polynomialDerivative(poly: Polynomial): Polynomial {
+    if (poly.length <= 1) return [0];
+    const result: number[] = new Array(poly.length - 1);
+    for (let i = 1; i < poly.length; i++) {
+        result[i - 1] = poly[i] * i;
+    }
+    return result;
+}
+
+export function positiveRootUpperBound(poly: Polynomial): number {
+    const n = poly.length - 1;
+    const leading = Math.abs(poly[n]);
+    if (leading === 0) return 0;
+    let maxCoeff = 0;
+    for (let i = 0; i < n; i++) {
+        maxCoeff = Math.max(maxCoeff, Math.abs(poly[i]));
+    }
+    return 1 + maxCoeff / leading;
+}
+
+export function bisectionRoot(poly: Polynomial, a: number, b: number, tol = 1e-7): number {
+    let fa = evaluatePolynomial(poly, a);
+    let fb = evaluatePolynomial(poly, b);
+    if (fa * fb > 0) throw new Error('Root not bracketed');
+    for (let i = 0; i < 100; i++) {
+        const mid = (a + b) / 2;
+        const fm = evaluatePolynomial(poly, mid);
+        if (Math.abs(fm) < tol || (b - a) / 2 < tol) return mid;
+        if (fa * fm <= 0) {
+            b = mid;
+            fb = fm;
+        } else {
+            a = mid;
+            fa = fm;
+        }
+    }
+    return (a + b) / 2;
+}
+
+export function findPositiveRoots(poly: Polynomial, tol = 1e-7): number[] {
+    const bound = positiveRootUpperBound(poly);
+    if (bound === 0) return [];
+    const stepCount = 1000;
+    const step = bound / stepCount;
+    const roots: number[] = [];
+    let prevX = 0;
+    let prevY = evaluatePolynomial(poly, prevX);
+    for (let i = 1; i <= stepCount; i++) {
+        const x = i * step;
+        const y = evaluatePolynomial(poly, x);
+        if (Math.abs(y) < tol) {
+            roots.push(x);
+        } else if (prevY * y < 0) {
+            roots.push(bisectionRoot(poly, prevX, x, tol));
+        }
+        prevX = x;
+        prevY = y;
+    }
+    return roots;
+}

--- a/src/types/durand-kerner.d.ts
+++ b/src/types/durand-kerner.d.ts
@@ -1,0 +1,1 @@
+declare module 'durand-kerner';

--- a/src/types/poly-roots.d.ts
+++ b/src/types/poly-roots.d.ts
@@ -1,0 +1,1 @@
+declare module 'poly-roots';

--- a/tests/PolynomialMinimizer.test.ts
+++ b/tests/PolynomialMinimizer.test.ts
@@ -1,0 +1,25 @@
+import { positiveGlobalMinimizer } from '../src/simulation/utils/PolynomialMinimizer';
+
+describe('positiveGlobalMinimizer', () => {
+    test('finds minimizer for quadratic polynomial', () => {
+        // p(x) = 2 - 4x + 2x^2 -> minimum at x=1
+        const poly = [2, -4, 2];
+        const min = positiveGlobalMinimizer(poly);
+        expect(min).not.toBeNull();
+        expect(min!).toBeCloseTo(1);
+    });
+
+    test('returns null when polynomial is unbounded below', () => {
+        // p(x) = -1 + x - x^2, leading coefficient negative
+        const poly = [-1, 1, -1];
+        const min = positiveGlobalMinimizer(poly);
+        expect(min).toBeNull();
+    });
+
+    test('returns null when minimum occurs at zero', () => {
+        // p(x) = x^3 - 6x^2 + 12x -> minimum at 0
+        const poly = [0, 12, -6, 1];
+        const min = positiveGlobalMinimizer(poly);
+        expect(min).toBeNull();
+    });
+});

--- a/tests/PolynomialMinimizerDK.test.ts
+++ b/tests/PolynomialMinimizerDK.test.ts
@@ -1,0 +1,22 @@
+import { positiveGlobalMinimizerDK } from '../src/simulation/utils/PolynomialMinimizerDK';
+
+describe('positiveGlobalMinimizerDK', () => {
+    test('finds minimizer for quadratic polynomial', () => {
+        const poly = [2, -4, 2];
+        const min = positiveGlobalMinimizerDK(poly);
+        expect(min).not.toBeNull();
+        expect(min!).toBeCloseTo(1);
+    });
+
+    test('returns null when polynomial is unbounded below', () => {
+        const poly = [-1, 1, -1];
+        const min = positiveGlobalMinimizerDK(poly);
+        expect(min).toBeNull();
+    });
+
+    test('returns null when minimum occurs at zero', () => {
+        const poly = [0, 12, -6, 1];
+        const min = positiveGlobalMinimizerDK(poly);
+        expect(min).toBeNull();
+    });
+});

--- a/tests/PolynomialMinimizerJT.test.ts
+++ b/tests/PolynomialMinimizerJT.test.ts
@@ -1,0 +1,22 @@
+import { positiveGlobalMinimizerJT } from '../src/simulation/utils/PolynomialMinimizerJT';
+
+describe('positiveGlobalMinimizerJT', () => {
+    test('finds minimizer for quadratic polynomial', () => {
+        const poly = [2, -4, 2];
+        const min = positiveGlobalMinimizerJT(poly);
+        expect(min).not.toBeNull();
+        expect(min!).toBeCloseTo(1);
+    });
+
+    test('returns null when polynomial is unbounded below', () => {
+        const poly = [-1, 1, -1];
+        const min = positiveGlobalMinimizerJT(poly);
+        expect(min).toBeNull();
+    });
+
+    test('returns null when minimum occurs at zero', () => {
+        const poly = [0, 12, -6, 1];
+        const min = positiveGlobalMinimizerJT(poly);
+        expect(min).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- add a simple polynomial utils module for evaluation, derivative and basic root finding
- add a positive global minimizer solver using the utils
- add Durand-Kerner and Jenkins–Traub implementations for minimizer search
- include benchmark script for comparing minimizers

## Testing
- `npm install`
- `npm test`
- `npx tsc --module commonjs --outDir dist-cjs`
- `node bench/runBenchmark.js`

------
https://chatgpt.com/codex/tasks/task_e_683f6d92dcb4832b94712e377ff4188c