### PR TITLE
Fix EventCallback exports

### DIFF
--- a/src/communication/EventBus.ts
+++ b/src/communication/EventBus.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from './EventEmitter';
+import { EventCallback } from './types/EventCallback';
 
 export class EventBus {
     private emitters: Map<Function, EventEmitter<any>> = new Map();

--- a/src/communication/EventEmitter.ts
+++ b/src/communication/EventEmitter.ts
@@ -1,3 +1,5 @@
+import { EventCallback } from './types/EventCallback';
+
 export class EventEmitter<T> {
     private listeners: Map<EventCallback<T>, any> = new Map();
 

--- a/src/communication/types/EventCallback.ts
+++ b/src/communication/types/EventCallback.ts
@@ -1,1 +1,1 @@
-type EventCallback<T> = (event: T) => void;
+export type EventCallback<T> = (event: T) => void;


### PR DESCRIPTION
## Summary
- export `EventCallback` type
- import `EventCallback` in `EventEmitter` and `EventBus`

## Testing
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f96e0e5bc832bb40db50895dbf9de